### PR TITLE
Fix inconsistent error display messages

### DIFF
--- a/src/main/java/seedu/forgetfulnus/commons/core/Messages.java
+++ b/src/main/java/seedu/forgetfulnus/commons/core/Messages.java
@@ -8,9 +8,13 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX =
             "The flashcard index provided is invalid!";
+    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_PREFIX_PARAM = " %s is not a valid prefix parameter.";
+    public static final String MESSAGE_INVALID_SORT_PARAM = " %s is not a valid sort parameter.";
     public static final String MESSAGE_PHRASES_LISTED_OVERVIEW = "%1$d flashcard(s) listed!\n"
             + "Type 'list' to show entire glossary.";
     public static final String MESSAGE_QUIZ_ALREADY_STARTED =
             "Quiz has already started! Enter 'end' to end quizzing.";
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command!";
+    public static final String MESSAGE_ZERO_INDEX = "Index is 0.";
 }

--- a/src/main/java/seedu/forgetfulnus/logic/Logic.java
+++ b/src/main/java/seedu/forgetfulnus/logic/Logic.java
@@ -7,6 +7,7 @@ import seedu.forgetfulnus.commons.core.GuiSettings;
 import seedu.forgetfulnus.logic.commands.CommandResult;
 import seedu.forgetfulnus.logic.commands.exceptions.CommandException;
 import seedu.forgetfulnus.logic.parser.exceptions.ParseException;
+import seedu.forgetfulnus.logic.parser.exceptions.ParseZeroException;
 import seedu.forgetfulnus.model.ReadOnlyGlossary;
 import seedu.forgetfulnus.model.flashcard.FlashCard;
 
@@ -21,7 +22,7 @@ public interface Logic {
      * @throws CommandException If an error occurs during command execution.
      * @throws ParseException If an error occurs during parsing.
      */
-    CommandResult execute(String commandText) throws CommandException, ParseException;
+    CommandResult execute(String commandText) throws CommandException, ParseException, ParseZeroException;
 
     /**
      * Returns the Glossary.

--- a/src/main/java/seedu/forgetfulnus/logic/LogicManager.java
+++ b/src/main/java/seedu/forgetfulnus/logic/LogicManager.java
@@ -12,6 +12,7 @@ import seedu.forgetfulnus.logic.commands.CommandResult;
 import seedu.forgetfulnus.logic.commands.exceptions.CommandException;
 import seedu.forgetfulnus.logic.parser.GlossaryParser;
 import seedu.forgetfulnus.logic.parser.exceptions.ParseException;
+import seedu.forgetfulnus.logic.parser.exceptions.ParseZeroException;
 import seedu.forgetfulnus.model.Model;
 import seedu.forgetfulnus.model.ReadOnlyGlossary;
 import seedu.forgetfulnus.model.flashcard.FlashCard;
@@ -39,7 +40,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public CommandResult execute(String commandText) throws CommandException, ParseException {
+    public CommandResult execute(String commandText) throws CommandException, ParseException, ParseZeroException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;

--- a/src/main/java/seedu/forgetfulnus/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/forgetfulnus/logic/parser/DeleteCommandParser.java
@@ -1,10 +1,12 @@
 package seedu.forgetfulnus.logic.parser;
 
 import static seedu.forgetfulnus.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.forgetfulnus.commons.core.Messages.MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX;
 
 import seedu.forgetfulnus.commons.core.index.Index;
 import seedu.forgetfulnus.logic.commands.DeleteCommand;
 import seedu.forgetfulnus.logic.parser.exceptions.ParseException;
+import seedu.forgetfulnus.logic.parser.exceptions.ParseZeroException;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -14,15 +16,21 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
+     * @throws ParseZeroException if the user input is '0'.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public DeleteCommand parse(String args) throws ParseException {
+    public DeleteCommand parse(String args) throws ParseException, ParseZeroException {
         try {
             Index index = ParserUtil.parseIndex(args);
             return new DeleteCommand(index);
+        } catch (ParseZeroException pze) {
+            throw new ParseZeroException(
+                    String.format(MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX,
+                            DeleteCommand.MESSAGE_USAGE), pze);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/seedu/forgetfulnus/logic/parser/GlossaryParser.java
+++ b/src/main/java/seedu/forgetfulnus/logic/parser/GlossaryParser.java
@@ -23,6 +23,7 @@ import seedu.forgetfulnus.logic.commands.ScoreCommand;
 import seedu.forgetfulnus.logic.commands.SortCommand;
 import seedu.forgetfulnus.logic.commands.TryCommand;
 import seedu.forgetfulnus.logic.parser.exceptions.ParseException;
+import seedu.forgetfulnus.logic.parser.exceptions.ParseZeroException;
 
 /**
  * Parses user input.
@@ -39,9 +40,10 @@ public class GlossaryParser {
      *
      * @param userInput full user input string
      * @return the command based on the user input
+     * @throws ParseZeroException if the user input is '0'.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public Command parseCommand(String userInput) throws ParseException {
+    public Command parseCommand(String userInput) throws ParseException, ParseZeroException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/forgetfulnus/logic/parser/Parser.java
+++ b/src/main/java/seedu/forgetfulnus/logic/parser/Parser.java
@@ -2,6 +2,7 @@ package seedu.forgetfulnus.logic.parser;
 
 import seedu.forgetfulnus.logic.commands.Command;
 import seedu.forgetfulnus.logic.parser.exceptions.ParseException;
+import seedu.forgetfulnus.logic.parser.exceptions.ParseZeroException;
 
 /**
  * Represents a Parser that is able to parse user input into a {@code Command} of type {@code T}.
@@ -10,7 +11,8 @@ public interface Parser<T extends Command> {
 
     /**
      * Parses {@code userInput} into a command and returns it.
+     * @throws ParseZeroException if the user input is '0'.
      * @throws ParseException if {@code userInput} does not conform the expected format
      */
-    T parse(String userInput) throws ParseException;
+    T parse(String userInput) throws ParseException, ParseZeroException;
 }

--- a/src/main/java/seedu/forgetfulnus/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/forgetfulnus/logic/parser/ParserUtil.java
@@ -1,6 +1,10 @@
 package seedu.forgetfulnus.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.forgetfulnus.commons.core.Messages.MESSAGE_INVALID_INDEX;
+import static seedu.forgetfulnus.commons.core.Messages.MESSAGE_INVALID_PREFIX_PARAM;
+import static seedu.forgetfulnus.commons.core.Messages.MESSAGE_INVALID_SORT_PARAM;
+import static seedu.forgetfulnus.commons.core.Messages.MESSAGE_ZERO_INDEX;
 import static seedu.forgetfulnus.logic.parser.CliSyntax.PREFIX_DIFFICULTY_TAG;
 import static seedu.forgetfulnus.logic.parser.CliSyntax.PREFIX_GENDER_TAG;
 
@@ -11,6 +15,7 @@ import java.util.Set;
 import seedu.forgetfulnus.commons.core.index.Index;
 import seedu.forgetfulnus.commons.util.StringUtil;
 import seedu.forgetfulnus.logic.parser.exceptions.ParseException;
+import seedu.forgetfulnus.logic.parser.exceptions.ParseZeroException;
 import seedu.forgetfulnus.model.flashcard.EnglishPhrase;
 import seedu.forgetfulnus.model.flashcard.GermanPhrase;
 import seedu.forgetfulnus.model.tag.DifficultyTag;
@@ -23,18 +28,17 @@ import seedu.forgetfulnus.model.tag.Tag;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    public static final String MESSAGE_INVALID_SORT_PARAM = " %s is not a valid sort parameter.";
-    public static final String MESSAGE_INVALID_PREFIX_PARAM = " %s is not a valid prefix parameter.";
-
-
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
+     * @throws ParseZeroException if the specified index is '0'.
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
-    public static Index parseIndex(String oneBasedIndex) throws ParseException {
+    public static Index parseIndex(String oneBasedIndex) throws ParseException, ParseZeroException {
         String trimmedIndex = oneBasedIndex.trim();
+        if (trimmedIndex.equals("0")) {
+            throw new ParseZeroException(MESSAGE_ZERO_INDEX);
+        }
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }

--- a/src/main/java/seedu/forgetfulnus/logic/parser/RandomQuizCommandParser.java
+++ b/src/main/java/seedu/forgetfulnus/logic/parser/RandomQuizCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.forgetfulnus.logic.parser;
 
 import static seedu.forgetfulnus.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.forgetfulnus.commons.core.Messages.MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -8,6 +9,7 @@ import java.util.logging.Logger;
 import seedu.forgetfulnus.commons.core.index.Index;
 import seedu.forgetfulnus.logic.commands.RandomQuizCommand;
 import seedu.forgetfulnus.logic.parser.exceptions.ParseException;
+import seedu.forgetfulnus.logic.parser.exceptions.ParseZeroException;
 
 /**
  * Parses input arguments and creates a new RandomQuizCommand object.
@@ -19,15 +21,21 @@ public class RandomQuizCommandParser implements Parser<RandomQuizCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the RandomQuizCommand
      * and returns a RandomQuizCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseZeroException if the user input is '0'.
+     * @throws ParseException if the user input does not conform the expected format.
      */
-    public RandomQuizCommand parse(String args) throws ParseException {
+    public RandomQuizCommand parse(String args) throws ParseException, ParseZeroException {
         logger.log(Level.INFO, "Start processing arguments");
         try {
             Index index = ParserUtil.parseIndex(args);
             assert index.getOneBased() > 0 : "Parameter of RandomQuizCommand must be more than 0";
             logger.log(Level.INFO, "End of processing");
             return new RandomQuizCommand(index);
+        } catch (ParseZeroException pze) {
+            logger.log(Level.WARNING, "Processing error");
+            throw new ParseZeroException(
+                    String.format(MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX,
+                            RandomQuizCommand.MESSAGE_USAGE), pze);
         } catch (ParseException pe) {
             logger.log(Level.WARNING, "Processing error");
             throw new ParseException(

--- a/src/main/java/seedu/forgetfulnus/logic/parser/exceptions/ParseZeroException.java
+++ b/src/main/java/seedu/forgetfulnus/logic/parser/exceptions/ParseZeroException.java
@@ -1,0 +1,15 @@
+package seedu.forgetfulnus.logic.parser.exceptions;
+
+/**
+ * Represents a parse error due to a param of '0' encountered by a parser.
+ */
+public class ParseZeroException extends ParseException {
+
+    public ParseZeroException(String message) {
+        super(message);
+    }
+
+    public ParseZeroException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/seedu/forgetfulnus/ui/CommandBox.java
+++ b/src/main/java/seedu/forgetfulnus/ui/CommandBox.java
@@ -7,6 +7,7 @@ import javafx.scene.layout.Region;
 import seedu.forgetfulnus.logic.commands.CommandResult;
 import seedu.forgetfulnus.logic.commands.exceptions.CommandException;
 import seedu.forgetfulnus.logic.parser.exceptions.ParseException;
+import seedu.forgetfulnus.logic.parser.exceptions.ParseZeroException;
 
 /**
  * The UI component that is responsible for receiving user command inputs.
@@ -74,7 +75,7 @@ public class CommandBox extends UiPart<Region> {
          *
          * @see seedu.forgetfulnus.logic.Logic#execute(String)
          */
-        CommandResult execute(String commandText) throws CommandException, ParseException;
+        CommandResult execute(String commandText) throws CommandException, ParseException, ParseZeroException;
     }
 
 }

--- a/src/main/java/seedu/forgetfulnus/ui/MainWindow.java
+++ b/src/main/java/seedu/forgetfulnus/ui/MainWindow.java
@@ -16,6 +16,7 @@ import seedu.forgetfulnus.logic.Logic;
 import seedu.forgetfulnus.logic.commands.CommandResult;
 import seedu.forgetfulnus.logic.commands.exceptions.CommandException;
 import seedu.forgetfulnus.logic.parser.exceptions.ParseException;
+import seedu.forgetfulnus.logic.parser.exceptions.ParseZeroException;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -177,7 +178,8 @@ public class MainWindow extends UiPart<Stage> {
      *
      * @see seedu.forgetfulnus.logic.Logic#execute(String)
      */
-    private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
+    private CommandResult executeCommand(String commandText) throws CommandException,
+            ParseException, ParseZeroException {
         try {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());

--- a/src/test/java/seedu/forgetfulnus/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/forgetfulnus/logic/LogicManagerTest.java
@@ -20,6 +20,7 @@ import seedu.forgetfulnus.logic.commands.CommandResult;
 import seedu.forgetfulnus.logic.commands.ListCommand;
 import seedu.forgetfulnus.logic.commands.exceptions.CommandException;
 import seedu.forgetfulnus.logic.parser.exceptions.ParseException;
+import seedu.forgetfulnus.logic.parser.exceptions.ParseZeroException;
 import seedu.forgetfulnus.model.Glossary;
 import seedu.forgetfulnus.model.Model;
 import seedu.forgetfulnus.model.ModelManager;
@@ -105,7 +106,7 @@ public class LogicManagerTest {
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandSuccess(String inputCommand, String expectedMessage,
-            Model expectedModel) throws CommandException, ParseException {
+            Model expectedModel) throws CommandException, ParseException, ParseZeroException {
         CommandResult result = logic.execute(inputCommand);
         assertEquals(expectedMessage, result.getFeedbackToUser());
         assertEquals(expectedModel, model);

--- a/src/test/java/seedu/forgetfulnus/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/forgetfulnus/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.forgetfulnus.logic.parser;
 
 import static seedu.forgetfulnus.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.forgetfulnus.commons.core.Messages.MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX;
 import static seedu.forgetfulnus.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.forgetfulnus.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.forgetfulnus.testutil.TypicalIndexes.INDEX_FIRST_FLASHCARD;
@@ -27,6 +28,13 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseZeroException() {
+        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX,
+                DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/forgetfulnus/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/forgetfulnus/logic/parser/ParserUtilTest.java
@@ -2,7 +2,7 @@ package seedu.forgetfulnus.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.forgetfulnus.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.forgetfulnus.commons.core.Messages.MESSAGE_INVALID_INDEX;
 import static seedu.forgetfulnus.testutil.Assert.assertThrows;
 import static seedu.forgetfulnus.testutil.TypicalIndexes.INDEX_FIRST_FLASHCARD;
 
@@ -14,6 +14,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.forgetfulnus.logic.parser.exceptions.ParseException;
+import seedu.forgetfulnus.logic.parser.exceptions.ParseZeroException;
 import seedu.forgetfulnus.model.flashcard.EnglishPhrase;
 import seedu.forgetfulnus.model.flashcard.GermanPhrase;
 import seedu.forgetfulnus.model.tag.Tag;
@@ -33,6 +34,11 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseIndex("10 a"));
+    }
+
+    @Test
+    public void parseIndex_invalidInput_throwsParseZeroException() {
+        assertThrows(ParseZeroException.class, () -> ParserUtil.parseIndex("0"));
     }
 
     @Test

--- a/src/test/java/seedu/forgetfulnus/logic/parser/RandomQuizCommandParserTest.java
+++ b/src/test/java/seedu/forgetfulnus/logic/parser/RandomQuizCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.forgetfulnus.logic.parser;
 
 import static seedu.forgetfulnus.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.forgetfulnus.commons.core.Messages.MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX;
 import static seedu.forgetfulnus.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.forgetfulnus.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.forgetfulnus.testutil.TypicalIndexes.INDEX_FIVE_FLASHCARDS;
@@ -28,6 +29,12 @@ public class RandomQuizCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                RandomQuizCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseZeroException() {
+        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX,
                 RandomQuizCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
Fix inconsistent error display messages particularly for the case of the parameter '0' for:
- DeleteCommand
- RandomQuizCommand